### PR TITLE
타임라인 페이지 추가

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -33,3 +33,61 @@ nav {
 .content {
   @extend .col-md-6;
 }
+
+.micropost {
+  $thumbnail-size: 2.5rem;
+
+  &-list-entry, &-form {
+    display: flex;
+  }
+
+  &-thumbnail {
+    padding-top: 0.25rem;
+    flex-basis: $thumbnail-size;
+
+    img {
+      width: $thumbnail-size;
+      height: $thumbnail-size;
+      border-radius: $thumbnail-size;
+    }
+  }
+
+  &-body {
+    margin-left: .75rem;
+    flex-basis: calc(100% - $thumbnail-size);
+
+    textarea {
+      border: none;
+    }
+  }
+
+  &-action {
+    padding: 0;
+    color: var(--bs-color);
+
+    width: 1.5rem;
+    height: 1.5rem;
+
+    text-align: center;
+    border-radius: 1.5rem;
+
+    cursor: pointer;
+
+    &::after {
+      content: none;
+    }
+
+    &:hover {
+      background-color: #cfcfcf;
+      opacity: 0.5;
+    }
+
+    & + ul button {
+      width: 100%;
+      text-align: left;
+      color: var(--bs-body-color);
+      background: transparent;
+      border: none;
+    }
+  }
+}

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -1,0 +1,36 @@
+class MicropostsController < ApplicationController
+  # GET /microposts
+  def index
+    @micropost = Micropost.new
+    @microposts = Micropost.all.order("created_at desc")
+  end
+
+  # POST /microposts
+  def create
+    @micropost = Micropost.new(micropost_params)
+
+    respond_to do |format|
+      if @micropost.save
+        format.html { redirect_to microposts_url, notice: "Micropost was successfully created." }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /microposts/1 or /microposts/1.json
+  def destroy
+    @micropost = Micropost.find(params[:id])
+    @micropost.destroy
+
+    respond_to do |format|
+      format.html { redirect_to microposts_url, notice: "Micropost was successfully destroyed." }
+    end
+  end
+
+  private
+    # Only allow a list of trusted parameters through.
+    def micropost_params
+      params.require(:micropost).permit(:content, :username)
+    end
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,0 +1,2 @@
+class Micropost < ApplicationRecord
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
   </head>
 
   <body>

--- a/app/views/microposts/_form.html.erb
+++ b/app/views/microposts/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with(model: micropost, class: "micropost-form") do |form| %>
+  <div class="micropost-thumbnail">
+    <%= image_tag "https://via.placeholder.com/40" %>
+  </div>
+  <div class="micropost-body">
+    <%= form.text_area :content, placeholder: "무슨 일이 일어나고 있나요?", class: 'form-control' %>
+    <%= form.hidden_field :username, value: "아무개" %>
+
+    <div class="d-flex justify-content-end my-2 mb-4">
+      <%= form.submit "글쓰기", class: "btn btn-primary" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/microposts/_micropost.html.erb
+++ b/app/views/microposts/_micropost.html.erb
@@ -1,0 +1,24 @@
+<div id="<%= dom_id micropost %>" class="micropost-list-entry p-2">
+  <div class="micropost-thumbnail">
+    <%= image_tag "https://via.placeholder.com/40" %>
+  </div>
+  <div class="micropost-body">
+    <div class="micropost-header d-flex justify-content-between mb-1">
+      <div class="micropost-information">
+        <b><%= micropost.username %></b>
+      </div>
+      <button type="button" class="btn dropdown-toggle micropost-action" data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="bi bi-three-dots"></i>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end">
+        <%#= link_to 메서드로는 해결되지 않아 button_to로 대체함 %>
+        <li class="dropdown-item">
+          <%= button_to "글 삭제하기", micropost_path(micropost), method: :delete %>
+        </li>
+      </ul>
+    </div>
+    <div class="micropost-content">
+      <%= micropost.content %>
+    </div>
+  </div>
+</div>

--- a/app/views/microposts/index.html.erb
+++ b/app/views/microposts/index.html.erb
@@ -1,0 +1,11 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render "form", micropost: @micropost %>
+
+<div id="microposts" class="card">
+  <% @microposts.each do |micropost| %>
+    <div class="border-bottom">
+      <%= render micropost %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :microposts, only: %I[index destroy create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/db/migrate/20220207135713_create_microposts.rb
+++ b/db/migrate/20220207135713_create_microposts.rb
@@ -1,0 +1,10 @@
+class CreateMicroposts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :microposts do |t|
+      t.string :content
+      t.string :username
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_02_07_135713) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "microposts", force: :cascade do |t|
+    t.string "content"
+    t.string "username"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/test/controllers/microposts_controller_test.rb
+++ b/test/controllers/microposts_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class MicropostsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @micropost = create(:micropost)
+  end
+
+  test "should get index" do
+    get microposts_url
+    assert_response :success
+  end
+
+  test "should create micropost" do
+    assert_difference("Micropost.count") do
+      post microposts_url, params: { micropost: { content: @micropost.content, username: @micropost.username } }
+    end
+  end
+
+  test "should destroy micropost" do
+    assert_difference("Micropost.count", -1) do
+      delete micropost_url(@micropost)
+    end
+
+    assert_redirected_to microposts_url
+  end
+end

--- a/test/factories/microposts.rb
+++ b/test/factories/microposts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :micropost do
+    content { 'Sample' }
+    username { 'Sample Username' }
+  end
+end

--- a/test/models/micropost_test.rb
+++ b/test/models/micropost_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MicropostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/microposts_test.rb
+++ b/test/system/microposts_test.rb
@@ -1,0 +1,35 @@
+require "application_system_test_case"
+
+class MicropostsTest < ApplicationSystemTestCase
+  setup do
+    @micropost = create(:micropost)
+  end
+
+  test "visiting the index" do
+    visit microposts_url
+    assert_selector "textarea"
+  end
+
+  test "should create micropost" do
+    visit microposts_url
+
+    assert_difference("Micropost.count", 1) do
+      within(".micropost-form") do
+        fill_in "micropost[content]", with: @micropost.content
+      end
+      click_on "글쓰기"
+    end
+
+    assert_text "Micropost was successfully created"
+  end
+
+  test "should destroy Micropost" do
+    visit microposts_url
+
+    find(".micropost-action").click
+    assert_difference("Micropost.count", -1) do
+      click_on "글 삭제하기", match: :first
+      sleep(0.1)
+    end
+  end
+end


### PR DESCRIPTION
* 타임라인에 보여지는 마이크로포스트를 나타내는 컴포넌트도 추가적으로 구현함
* 간단한 구현 레벨의 타임라인 페이지에서 글 작성, 리스트 조회, 글 삭제가 올바르게 작동되는지 확인할 수 있도록 e2e 테스트를 작성함

### Screenshot

![Deepin스크린샷_선택 영역_20220209024325](https://user-images.githubusercontent.com/2427963/153045114-e252d45b-8208-405f-906a-c8964c677cf8.png)
